### PR TITLE
Minor change to fix a delete issue

### DIFF
--- a/SEModAPIInternal/API/Entity/BaseEntity.cs
+++ b/SEModAPIInternal/API/Entity/BaseEntity.cs
@@ -676,7 +676,8 @@ namespace SEModAPIInternal.API.Entity
 			{
 				m_nextEntityToUpdate = gameEntity;
 				HkRigidBody havokBody = GetRigidBody(m_nextEntityToUpdate);
-				m_nextEntityPosition = Vector3.Multiply(havokBody.Position, 1000);
+                m_nextEntityPosition = Vector3.Add(havokBody.Position, new Vector3(100000,100000,100000));
+                m_nextEntityPosition = Vector3.Multiply(m_nextEntityPosition, 1000);
 
 				Action action = InternalUpdateEntityPosition;
 				SandboxGameAssemblyWrapper.EnqueueMainGameAction(action);

--- a/SEModAPIInternal/Properties/AssemblyInfo.cs
+++ b/SEModAPIInternal/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.1.2.0")]
-[assembly: AssemblyFileVersion("0.1.2.0")]
+[assembly: AssemblyVersion("0.1.2.1")]
+[assembly: AssemblyFileVersion("0.1.2.1")]


### PR DESCRIPTION
If x,y,z are all less than 50 an item can be teleported in visible range of someone in the sector, or not move at all (in case of objects at origin). This change should guarantee the item is moved outside of the sector before the deletion is done. 
